### PR TITLE
Improvement: use file extension if filetype.guess fails

### DIFF
--- a/instapy_cli/cli.py
+++ b/instapy_cli/cli.py
@@ -138,9 +138,10 @@ class InstapyCli(object):
 
 
         except Exception as e:
-            print('Error is >>\n    ' + str(e))
-            print('\nSomething went bad.\nPlease retry or send an issue on https://github.com/b3nab/instapy-cli\n')
+         #   print('Error is >>\n    ' + str(e))
+         #   print('\nSomething went bad.\nPlease retry or send an issue on https://github.com/b3nab/instapy-cli\n')
             upload_completed = False
+            raise IOError(str(e), '\nSomething went bad.\nPlease retry or send an issue on https://github.com/b3nab/instapy-cli\n')
 
         finally:
             # media_status = 'YES' if media.isDownloaded() else 'NO'

--- a/instapy_cli/media.py
+++ b/instapy_cli/media.py
@@ -3,6 +3,9 @@ from instagram_private_api import MediaRatios
 from instagram_private_api_extensions import media as IGMedia
 import filetype
 #import urlparse for Python2 and Python3
+import logging
+
+log = logging.getLogger("instapy")
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -18,6 +21,7 @@ class Media(object):
     isLink = False
 
     def __init__(self, file, ratio='post'):
+        log.info("NEW instanceof MEDIA")
         # if file is link
         if urlparse(file).scheme in ('http', 'https'):
             self.media_path = self.downloadMediaFromLink(file)

--- a/instapy_cli/media.py
+++ b/instapy_cli/media.py
@@ -25,15 +25,20 @@ class Media(object):
         # if file is a local file
         else:
             self.media_path = file
-        
+
         self.check_type()
-    
+
     def check_type(self):
-        self.media_ext = filetype.guess(self.media_path).extension
-    
+        ext = filetype.guess(self.media_path)
+        if None is self.media_ext:
+            absolute_path = os.path.abspath(self.media_path)
+            self.media_ext = os.path.splitext(absolute_path)[-1].replace(".", "")
+        else:
+            self.media_ext = ext.extension
+
     def is_image(self):
         return True if self.media_ext in ['jpg', 'png', 'gif'] else False
-        
+
     def is_video(self):
         return True if self.media_ext in ['mp4', 'mov', 'avi'] else False
 

--- a/instapy_cli/media.py
+++ b/instapy_cli/media.py
@@ -3,9 +3,6 @@ from instagram_private_api import MediaRatios
 from instagram_private_api_extensions import media as IGMedia
 import filetype
 #import urlparse for Python2 and Python3
-import logging
-
-log = logging.getLogger("instapy")
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -21,7 +18,6 @@ class Media(object):
     isLink = False
 
     def __init__(self, file, ratio='post'):
-        log.info("NEW instanceof MEDIA")
         # if file is link
         if urlparse(file).scheme in ('http', 'https'):
             self.media_path = self.downloadMediaFromLink(file)


### PR DESCRIPTION
I created a more simple fix for https://github.com/instagrambot/instapy-cli/issues/46
every lib fails with mime type **application/octet-stream** so it now guesses by extension. 

Cheers and thanks for your awesome code!